### PR TITLE
Makes genomes annotated by prokka use unique ids, not gene names.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+### Version 1.0.4
+- Features IDs in the annotated genomes are now unique IDs generated
+  by Prokka, not gene names (the latter are now stored as feature aliases).
+
 ### Version 1.0.3
 - Check didn't work on for older contigs that were missing the metadata field
 

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    1.0.3
+    1.0.4
 
 owners:
     [rsutormin, umaganapathyswork, jmc, scanon]

--- a/lib/ProkkaAnnotation/ProkkaAnnotationImpl.py
+++ b/lib/ProkkaAnnotation/ProkkaAnnotationImpl.py
@@ -141,12 +141,12 @@ class ProkkaAnnotation:
             n_contigs = len(contig['data']['contigs'])
         if n_contigs >= 30000:
             print("Hmmm.  There are over 30,000 contigs in this Assembly. ")
-            print("It looks like you are trying to run Prokka on a metagenome or non-prokayritoc data set.")
+            print("It looks like you are trying to run Prokka on a metagenome or non-prokaryotic data set.")
             print("If this is a metagenome data set we recommend using an App like MaxBin to first bin the contigs into genome-like bins.")
             print("These bins can then be individually annotated as a single genome using Prokka.")
             print("If this data comes from a Eukaryotic sample, KBase does not currently have an annotation app designed for Eukaryotes.")
             print("Alternatively, you can try reducing the number of contigs using a filter app.")
-            raise ValueError('Too many contigs for Prokka.  See logs for details and suggestios')
+            raise ValueError('Too many contigs for Prokka.  See logs for details and suggestions')
 
         au = AssemblyUtil(os.environ['SDK_CALLBACK_URL'], token=ctx['token'])
         orig_fasta_file = au.get_assembly_as_fasta({'ref': assembly_ref})['path']

--- a/lib/ProkkaAnnotation/ProkkaAnnotationImpl.py
+++ b/lib/ProkkaAnnotation/ProkkaAnnotationImpl.py
@@ -249,8 +249,10 @@ class ProkkaAnnotation:
                     ec = self._get_qualifier_value(qualifiers.get('eC_number'))
                     gene = self._get_qualifier_value(qualifiers.get('gene'))
                     product = self._get_qualifier_value(qualifiers.get('product'))
-                    fid = name if name else generated_id
+                    fid = generated_id
                     aliases = []
+                    if name:
+                        aliases.append(name)
                     if gene:
                         aliases.append(gene)
                     if ec:

--- a/lib/ProkkaAnnotation/ProkkaAnnotationImpl.py
+++ b/lib/ProkkaAnnotation/ProkkaAnnotationImpl.py
@@ -141,12 +141,12 @@ class ProkkaAnnotation:
             n_contigs = len(contig['data']['contigs'])
         if n_contigs >= 30000:
             print "Hmmm.  There are over 30,000 contigs in this Assembly. "
-            print "It looks like you are trying to run Prokka on a metagenome or non-prokayritoc data set."
+            print "It looks like you are trying to run Prokka on a metagenome or non-prokaryotic data set."
             print "If this is a metagenome data set we recommend using an App like MaxBin to first bin the contigs into genome-like bins."
             print "These bins can then be individually annotated as a single genome using Prokka."
             print "If this data comes from a Eukaryotic sample, KBase does not currently have an annotation app designed for Eukaryotes."
             print "Alternatively, you can try reducing the number of contigs using a filter app."
-            raise ValueError('Too many contigs for Prokka.  See logs for details and suggestios')
+            raise ValueError('Too many contigs for Prokka.  See logs for details and suggestions')
 
         au = AssemblyUtil(os.environ['SDK_CALLBACK_URL'], token=ctx['token'])
         orig_fasta_file = au.get_assembly_as_fasta({'ref': assembly_ref})['path']

--- a/lib/ProkkaAnnotation/ProkkaAnnotationImpl.py
+++ b/lib/ProkkaAnnotation/ProkkaAnnotationImpl.py
@@ -141,12 +141,12 @@ class ProkkaAnnotation:
             n_contigs = len(contig['data']['contigs'])
         if n_contigs >= 30000:
             print "Hmmm.  There are over 30,000 contigs in this Assembly. "
-            print "It looks like you are trying to run Prokka on a metagenome or non-prokaryotic data set."
+            print "It looks like you are trying to run Prokka on a metagenome or non-prokayritoc data set."
             print "If this is a metagenome data set we recommend using an App like MaxBin to first bin the contigs into genome-like bins."
             print "These bins can then be individually annotated as a single genome using Prokka."
             print "If this data comes from a Eukaryotic sample, KBase does not currently have an annotation app designed for Eukaryotes."
             print "Alternatively, you can try reducing the number of contigs using a filter app."
-            raise ValueError('Too many contigs for Prokka.  See logs for details and suggestions')
+            raise ValueError('Too many contigs for Prokka.  See logs for details and suggestios')
 
         au = AssemblyUtil(os.environ['SDK_CALLBACK_URL'], token=ctx['token'])
         orig_fasta_file = au.get_assembly_as_fasta({'ref': assembly_ref})['path']


### PR DESCRIPTION
Fixes PTV-631.
Gene names are now stored as an alias instead of being the primary ID.
This allows downstream apps like BLAST and MUSCLE, which require unique feature IDs, to work.
This makes the Prokka importer's behavior consistent with the Genbank importer (you now get the
same IDs if you use Prokka inside of KBase as when you run it outside of KBase, then import the
resulting genome).